### PR TITLE
Add pseudotypes supported by psalm

### DIFF
--- a/src/com/jetbrains/php/psalm/types/PsalmExtendedStringDocTypeProvider.java
+++ b/src/com/jetbrains/php/psalm/types/PsalmExtendedStringDocTypeProvider.java
@@ -42,6 +42,8 @@ public class PsalmExtendedStringDocTypeProvider implements PhpTypeProvider4 {
     ,"non-empty-uppercase-string", PhpType.STRING
     ,"lowercase-string", PhpType.STRING
     ,"uppercase-string", PhpType.STRING
+    ,"uppercase-string", PhpType.STRING
+    ,"positive-int", PhpType.INT
   );
 
   public static final Collection<String> EXTENDED_SCALAR_TYPES = ContainerUtil.union(EXTENDED_STRINGS, ALTERNATIVE_SCALAR_TYPES.keySet());

--- a/src/com/jetbrains/php/psalm/types/PsalmExtendedStringDocTypeProvider.java
+++ b/src/com/jetbrains/php/psalm/types/PsalmExtendedStringDocTypeProvider.java
@@ -34,6 +34,14 @@ public class PsalmExtendedStringDocTypeProvider implements PhpTypeProvider4 {
     ,"never-return", PhpType.VOID
     ,"never-returns", PhpType.VOID
     ,"no-return", PhpType.VOID
+    ,"list", PhpType.ARRAY
+    ,"non-empty-list", PhpType.ARRAY
+    ,"non-empty-array", PhpType.ARRAY
+    ,"non-empty-string", PhpType.STRING
+    ,"non-empty-lowercase-string", PhpType.STRING
+    ,"non-empty-uppercase-string", PhpType.STRING
+    ,"lowercase-string", PhpType.STRING
+    ,"uppercase-string", PhpType.STRING
   );
 
   public static final Collection<String> EXTENDED_SCALAR_TYPES = ContainerUtil.union(EXTENDED_STRINGS, ALTERNATIVE_SCALAR_TYPES.keySet());


### PR DESCRIPTION
I think this is the place to add them but I don't really code in Java so I may be wrong.

Also, I noticed that "array-key" is categorized as a numeric. In reality, this is closer to string|int.