### PR TITLE
Add "int-mask" and "int-mask-of" types support

### DIFF
--- a/src/com/jetbrains/php/psalm/types/PsalmExtendedStringDocTypeProvider.java
+++ b/src/com/jetbrains/php/psalm/types/PsalmExtendedStringDocTypeProvider.java
@@ -44,6 +44,8 @@ public final class PsalmExtendedStringDocTypeProvider implements PhpTypeProvider
       ,"empty", PhpType.MIXED
       ,"positive-int", PhpType.INT
       ,"closed-resource", PhpType.RESOURCE
+      ,"int-mask-of", PhpType.INT
+      ,"int-mask", PhpType.INT
     ),
     NO_RETURN_TYPES
   );

--- a/testData/codeInsight/typeInference/IntMask.php
+++ b/testData/codeInsight/typeInference/IntMask.php
@@ -1,0 +1,4 @@
+<?php
+/** @psalm-var int-mask $f */
+$f = ff();
+<type value="int">$f</type>

--- a/testData/codeInsight/typeInference/IntMaskOf.php
+++ b/testData/codeInsight/typeInference/IntMaskOf.php
@@ -1,0 +1,4 @@
+<?php
+/** @psalm-var int-mask-of $f */
+$f = ff();
+<type value="int">$f</type>

--- a/tests/com/jetbrains/php/psalm/types/PsalmTypeInferenceTest.java
+++ b/tests/com/jetbrains/php/psalm/types/PsalmTypeInferenceTest.java
@@ -92,6 +92,14 @@ public class PsalmTypeInferenceTest extends PhpTypeInferenceTestCase {
     doTypeTest();
   }
 
+  public void testIntMask() {
+    doTypeTest();
+  }
+
+  public void testIntMaskOf() {
+    doTypeTest();
+  }
+
   public void testArrayKey() {
     doTypeTest();
   }


### PR DESCRIPTION
A little more psalm types has been added:
- `int-mask`
- `int-mask-of`

About int mask: https://psalm.dev/docs/running_psalm/plugins/plugins_type_system/
Usage example: https://github.com/vimeo/psalm/blob/4.6.1/stubs/Php80.phpstub#L63

Issue: https://youtrack.jetbrains.com/issue/WI-58772

P.S. I'm not sure if the tests are correct. it is difficult to check the functionality of this code in PhpStorm without instructions